### PR TITLE
Fix fog_distance causing resourcepack to not load in vanilla 1.20.5

### DIFF
--- a/objmc/assets/minecraft/shaders/core/render/block.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/block.vsh
@@ -43,5 +43,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance_custom(ModelViewMat, Pos, FogShape);
+    vertexDistance = fog_distance(Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/block.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/block.vsh
@@ -43,5 +43,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, Pos, FogShape);
+    vertexDistance = fog_distance_custom(ModelViewMat, Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/entity.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/entity.vsh
@@ -50,5 +50,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance_custom(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/entity.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/entity.vsh
@@ -50,5 +50,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance_custom(ModelViewMat, IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/entity_overlay.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/entity_overlay.vsh
@@ -52,5 +52,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance_custom(ModelViewMat, IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/entity_overlay.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/entity_overlay.vsh
@@ -52,5 +52,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance_custom(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/head.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/head.vsh
@@ -52,5 +52,5 @@ void main() {
     #moj_import<objmc_head.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance_custom(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/head.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/head.vsh
@@ -52,5 +52,5 @@ void main() {
     #moj_import<objmc_head.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance_custom(ModelViewMat, IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/include/fog.glsl
+++ b/objmc/assets/minecraft/shaders/include/fog.glsl
@@ -17,16 +17,6 @@ float linear_fog_fade(float vertexDistance, float fogStart, float fogEnd) {
     return smoothstep(fogEnd, fogStart, vertexDistance);
 }
 
-float fog_distance_custom(mat4 modelViewMat, vec3 pos, int shape) {
-    if (shape == 0) {
-        return length((modelViewMat * vec4(pos, 1.0)).xyz);
-    } else {
-        float distXZ = length((modelViewMat * vec4(pos.x, 0.0, pos.z, 1.0)).xyz);
-        float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
-        return max(distXZ, distY);
-    }
-}
-
 float fog_distance(vec3 pos, int shape) {
     if (shape == 0) {
         return length(pos);

--- a/objmc/assets/minecraft/shaders/include/fog.glsl
+++ b/objmc/assets/minecraft/shaders/include/fog.glsl
@@ -17,12 +17,22 @@ float linear_fog_fade(float vertexDistance, float fogStart, float fogEnd) {
     return smoothstep(fogEnd, fogStart, vertexDistance);
 }
 
-float fog_distance(mat4 modelViewMat, vec3 pos, int shape) {
+float fog_distance_custom(mat4 modelViewMat, vec3 pos, int shape) {
     if (shape == 0) {
         return length((modelViewMat * vec4(pos, 1.0)).xyz);
     } else {
         float distXZ = length((modelViewMat * vec4(pos.x, 0.0, pos.z, 1.0)).xyz);
         float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
+        return max(distXZ, distY);
+    }
+}
+
+float fog_distance(vec3 pos, int shape) {
+    if (shape == 0) {
+        return length(pos);
+    } else {
+        float distXZ = length(pos.xz);
+        float distY = abs(pos.y);
         return max(distXZ, distY);
     }
 }


### PR DESCRIPTION
Hey, the most recent version causes a crash in vanilla 1.20.5

This is because the default particle vertex shader is looking for a function called "fog_distance" which is a vanilla function.

However, it receives a modified fog_distance function with a different signature, and this causes an error.

This pull request changes all references to "fog_distance" into "fog_distance_custom" and adds back the vanilla version of the function, under the original name.

I have tested my changes in release version 1.20.5, and it loads. This is corroborated by two other people in the discord.

![image](https://github.com/Godlander/objmc/assets/88064574/a5a40546-1788-46d6-8583-4f5754d7c004)
