### PR TITLE
Fix 1.20.5 fog_distance

### DIFF
--- a/objmc/assets/minecraft/shaders/core/render/block.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/block.vsh
@@ -43,5 +43,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, Pos, FogShape);
+    vertexDistance = fog_distance_objmc(ModelViewMat, Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/entity.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/entity.vsh
@@ -50,5 +50,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance_objmc(ModelViewMat, IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/entity_overlay.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/entity_overlay.vsh
@@ -52,5 +52,5 @@ void main() {
     #moj_import <objmc_main.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance_objmc(ModelViewMat, IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/core/render/head.vsh
+++ b/objmc/assets/minecraft/shaders/core/render/head.vsh
@@ -52,5 +52,5 @@ void main() {
     #moj_import<objmc_head.glsl>
 
     gl_Position = ProjMat * ModelViewMat * vec4(Pos, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Pos, FogShape);
+    vertexDistance = fog_distance_objmc(ModelViewMat, IViewRotMat * Pos, FogShape);
 }

--- a/objmc/assets/minecraft/shaders/include/fog.glsl
+++ b/objmc/assets/minecraft/shaders/include/fog.glsl
@@ -17,12 +17,22 @@ float linear_fog_fade(float vertexDistance, float fogStart, float fogEnd) {
     return smoothstep(fogEnd, fogStart, vertexDistance);
 }
 
-float fog_distance(mat4 modelViewMat, vec3 pos, int shape) {
+float fog_distance_objmc(mat4 modelViewMat, vec3 pos, int shape) {
     if (shape == 0) {
         return length((modelViewMat * vec4(pos, 1.0)).xyz);
     } else {
         float distXZ = length((modelViewMat * vec4(pos.x, 0.0, pos.z, 1.0)).xyz);
         float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
+        return max(distXZ, distY);
+    }
+}
+
+float fog_distance(vec3 pos, int shape) {
+    if (shape == 0) {
+        return length(pos);
+    } else {
+        float distXZ = length(pos.xz);
+        float distY = abs(pos.y);
         return max(distXZ, distY);
     }
 }


### PR DESCRIPTION
Fix the fog_distance function for 1.20.5.

The fix is from TheMrPancake on discord.

Explanation from him : "The problem is the default files are looking for fog_distance, and they're getting the wrong function. So we're going to rename our custom fog_distance function and its uses within the files, and add back the default fog_distance function for the vanilla files to use"

Original messages from him : https://discord.com/channels/226104173987364866/343461169056579595/1232568163376435202 (Godlands Discord)

Screen from TheMrPancake
![image](https://github.com/Godlander/objmc/assets/94833069/b1fbd265-fa09-4ced-9dd3-823a441eecd4)

Screen from my game
![image](https://github.com/Godlander/objmc/assets/94833069/12588650-fde1-4490-9ce6-c0844f1d2721)
