### PR TITLE
Update to 1.21.11

### DIFF
--- a/objmc/assets/minecraft/shaders/core/entity.fsh
+++ b/objmc/assets/minecraft/shaders/core/entity.fsh
@@ -8,7 +8,12 @@ uniform sampler2D Sampler0;
 
 in float sphericalVertexDistance;
 in float cylindricalVertexDistance;
+#ifdef PER_FACE_LIGHTING
+in vec4 vertexPerFaceColorBack;
+in vec4 vertexPerFaceColorFront;
+#else
 in vec4 vertexColor;
+#endif
 
 in vec4 lightColor;
 in vec4 overlayColor;

--- a/objmc/assets/minecraft/shaders/core/entity.vsh
+++ b/objmc/assets/minecraft/shaders/core/entity.vsh
@@ -19,7 +19,12 @@ uniform sampler2D Sampler2;
 
 out float sphericalVertexDistance;
 out float cylindricalVertexDistance;
+#ifdef PER_FACE_LIGHTING
+out vec4 vertexPerFaceColorBack;
+out vec4 vertexPerFaceColorFront;
+#else
 out vec4 vertexColor;
+#endif
 
 out vec4 lightColor;
 out vec4 overlayColor;
@@ -39,8 +44,11 @@ void main() {
     texCoord = UV0;
     lightColor = vec4(1);
     overlayColor = texelFetch(Sampler1, UV1, 0);
-    vertexColor = vec4(1);
-#ifdef NO_CARDINAL_LIGHTING
+#ifdef PER_FACE_LIGHTING
+    vec2 light = minecraft_compute_light(Light0_Direction, Light1_Direction, Normal);
+    vertexPerFaceColorBack = minecraft_mix_light_separate(-light, Color);
+    vertexPerFaceColorFront = minecraft_mix_light_separate(light, Color);
+#elif defined(NO_CARDINAL_LIGHTING)
     vertexColor = Color;
 #else
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);

--- a/objmc/assets/minecraft/shaders/core/terrain.fsh
+++ b/objmc/assets/minecraft/shaders/core/terrain.fsh
@@ -1,8 +1,9 @@
 #version 150
 
 #moj_import <minecraft:fog.glsl>
+#moj_import <minecraft:globals.glsl>
+#moj_import <minecraft:chunksection.glsl>
 #moj_import <minecraft:light.glsl>
-#moj_import <minecraft:dynamictransforms.glsl>
 
 uniform sampler2D Sampler0;
 
@@ -21,8 +22,86 @@ flat in int noshadow;
 
 out vec4 fragColor;
 
+vec4 sampleNearest(sampler2D sampler, vec2 uv, vec2 pixelSize, vec2 du, vec2 dv, vec2 texelScreenSize) {
+    // Convert our UV back up to texel coordinates and find out how far over we are from the center of each pixel
+    vec2 uvTexelCoords = uv / pixelSize;
+    vec2 texelCenter = round(uvTexelCoords) - 0.5f;
+    vec2 texelOffset = uvTexelCoords - texelCenter;
+
+    // Move our offset closer to the texel center based on texel size on screen
+    texelOffset = (texelOffset - 0.5f) * pixelSize / texelScreenSize + 0.5f;
+    texelOffset = clamp(texelOffset, 0.0f, 1.0f);
+
+    uv = (texelCenter + texelOffset) * pixelSize;
+    return textureGrad(sampler, uv, du, dv);
+}
+
+vec4 sampleNearest(sampler2D source, vec2 uv, vec2 pixelSize) {
+    vec2 du = dFdx(uv);
+    vec2 dv = dFdy(uv);
+    vec2 texelScreenSize = sqrt(du * du + dv * dv);
+    return sampleNearest(source, uv, pixelSize, du, dv, texelScreenSize);
+}
+
+// Rotated Grid Super-Sampling
+vec4 sampleRGSS(sampler2D source, vec2 uv, vec2 pixelSize) {
+    vec2 du = dFdx(uv);
+    vec2 dv = dFdy(uv);
+
+    vec2 texelScreenSize = sqrt(du * du + dv * dv);
+    float maxTexelSize = max(texelScreenSize.x, texelScreenSize.y);
+
+    float minPixelSize = min(pixelSize.x, pixelSize.y);
+
+    float transitionStart = minPixelSize * 1.0;
+    float transitionEnd = minPixelSize * 2.0;
+    float blendFactor = smoothstep(transitionStart, transitionEnd, maxTexelSize);
+
+    float duLength = length(du);
+    float dvLength = length(dv);
+    float minDerivative = min(duLength, dvLength);
+    float maxDerivative = max(duLength, dvLength);
+
+    float effectiveDerivative = sqrt(minDerivative * maxDerivative);
+
+    float mipLevelExact = max(0.0, log2(effectiveDerivative / minPixelSize));
+
+    float mipLevelLow = floor(mipLevelExact);
+    float mipLevelHigh = mipLevelLow + 1.0;
+    float mipBlend = fract(mipLevelExact);
+
+    const vec2 offsets[4] = vec2[](
+    vec2(0.125, 0.375),
+    vec2(-0.125, -0.375),
+    vec2(0.375, -0.125),
+    vec2(-0.375, 0.125)
+    );
+
+    vec4 rgssColorLow = vec4(0.0);
+    vec4 rgssColorHigh = vec4(0.0);
+    for (int i = 0; i < 4; ++i) {
+        vec2 sampleUV = uv + offsets[i] * pixelSize;
+        rgssColorLow += textureLod(source, sampleUV, mipLevelLow);
+        rgssColorHigh += textureLod(source, sampleUV, mipLevelHigh);
+    }
+    rgssColorLow *= 0.25;
+    rgssColorHigh *= 0.25;
+
+    vec4 rgssColor = mix(rgssColorLow, rgssColorHigh, mipBlend);
+
+    vec4 nearestColor = sampleNearest(source, uv, pixelSize, du, dv, texelScreenSize);
+
+    return mix(nearestColor, rgssColor, blendFactor);
+}
+
+vec4 sampleColor(vec2 uv) {
+    if (isCustom == 1)
+        return texelFetch(Sampler0, ivec2(uv * textureSize(Sampler0, 0)), 0);
+    return UseRgss == 1 ? sampleRGSS(Sampler0, uv, 1.0f / TextureSize) : sampleNearest(Sampler0, uv, 1.0f / TextureSize);
+}
+
 void main() {
-    vec4 color = mix(texture(Sampler0, texCoord), texture(Sampler0, texCoord2), transition);
+    vec4 color = mix(sampleColor(texCoord), sampleColor(texCoord2), transition);
 
     //custom lighting
     #define BLOCK

--- a/objmc/assets/minecraft/shaders/core/terrain.vsh
+++ b/objmc/assets/minecraft/shaders/core/terrain.vsh
@@ -1,9 +1,9 @@
 #version 150
 
 #moj_import <minecraft:fog.glsl>
-#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
 #moj_import <minecraft:globals.glsl>
+#moj_import <minecraft:chunksection.glsl>
+#moj_import <minecraft:projection.glsl>
 
 in vec3 Position;
 in vec4 Color;
@@ -34,7 +34,7 @@ vec4 minecraft_sample_lightmap(sampler2D lightMap, ivec2 uv) {
 }
 
 void main() {
-    Pos = Position + ModelOffset;
+    Pos = Position + (ChunkPosition - CameraBlockPos) + CameraOffset;
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord = UV0;

--- a/objmc/assets/minecraft/shaders/include/objmc_light.glsl
+++ b/objmc/assets/minecraft/shaders/include/objmc_light.glsl
@@ -3,14 +3,19 @@
 
 //default lighting
 if (isCustom == 0) {
-    color *= vertexColor * ColorModulator;
 #ifndef EMISSIVE
     color *= lightColor;
+#endif
+#ifdef PER_FACE_LIGHTING
+    color *= (gl_FrontFacing ? vertexPerFaceColorFront : vertexPerFaceColorBack);
+#else
+    color *= vertexColor;
 #endif
 #ifdef ENTITY
 #ifndef NO_OVERLAY
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
 #endif
+    color *= ColorModulator;
 #endif
 }
 //custom lighting
@@ -33,5 +38,5 @@ else if (noshadow == 0) {
     color *= minecraft_mix_light(Light0_Direction, Light1_Direction, normal, overlayColor);
 #endif
 
-    color *= lightColor * ColorModulator;
+    color *= lightColor;
 }

--- a/objmc/pack.mcmeta
+++ b/objmc/pack.mcmeta
@@ -1,6 +1,8 @@
 {
   "pack": {
-    "pack_format": 64,
+    "pack_format": 75,
+    "min_format": 75,
+    "max_format": 75,
     "description": "example objmc pack"
   }
 }


### PR DESCRIPTION
Base game updates that were adapted in objmc with this PR:
* Block positions are stored in world space rather than player space. The old uniforms now no longer exist, this made blocks unable to render.
* The game now uses more advanced LOD on block textures. Neglecting to implement this made all blocks look blurry, and objmc textures now use `texelFetch` to avoid the seams at the model edges becoming visible on lower LOD.
* Entities now can have different lighting on the front and back. Objmc lighting now has directly adapted this change.